### PR TITLE
chore: cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,11 @@ jobs:
         run: |
           export PROVIDER_URI=${{ secrets.PROVIDER_URI_SEPOLIA }}
           mkdir data
-          cargo run --example keccak -- --input sdk/data/keccak_input.json -k 15 -c sdk/data/keccak_config.json keygen
-          cargo run --example keccak -- --input sdk/data/keccak_input.json -k 15 -c sdk/data/keccak_config.json run
-          cargo run --example rlc -- --input sdk/data/rlc_input.json -k 15 -c sdk/data/rlc_config.json keygen
-          cargo run --example rlc -- --input sdk/data/rlc_input.json -k 15 -c sdk/data/rlc_config.json run
-          cargo run --example account_age -- --input sdk/data/account_age_input.json -k 15 keygen
-          cargo run --example account_age -- --input sdk/data/account_age_input.json -k 15 run
-          cargo run --example quickstart -- --input sdk/data/quickstart_input.json -k 15 keygen
-          cargo run --example quickstart -- --input sdk/data/quickstart_input.json -k 15 run
+          cargo run --example keccak -- --input sdk/data/keccak_input.json --config sdk/data/keccak_config.json --aggregate --auto-config-aggregation keygen
+          cargo run --example keccak -- --input sdk/data/keccak_input.json --config sdk/data/keccak_config.json --aggregate run
+          cargo run --example rlc -- -c sdk/data/rlc_config.json keygen
+          cargo run --example rlc -- --input sdk/data/rlc_input.json run
+          cargo run --example account_age -- -k 15 keygen
+          cargo run --example account_age -- --input sdk/data/account_age_input.json run
+          cargo run --example quickstart -- -k 15 keygen
+          cargo run --example quickstart -- --input sdk/data/quickstart_input.json run

--- a/circuit/src/input/flatten.rs
+++ b/circuit/src/input/flatten.rs
@@ -5,9 +5,16 @@ use serde::{Deserialize, Serialize};
 use crate::{impl_input_flatten_for_fixed_array, impl_input_flatten_for_tuple};
 
 pub trait InputFlatten<T: Copy>: Sized {
+    type Params: Default = ();
     const NUM_FE: usize;
     fn flatten_vec(&self) -> Vec<T>;
     fn unflatten(vec: Vec<T>) -> Result<Self>;
+    fn params(&self) -> Self::Params {
+        Self::Params::default()
+    }
+    fn unflatten_with_params(vec: Vec<T>, _params: Self::Params) -> Result<Self> {
+        Self::unflatten(vec)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/circuit/src/input/flatten.rs
+++ b/circuit/src/input/flatten.rs
@@ -4,14 +4,22 @@ use serde::{Deserialize, Serialize};
 
 use crate::{impl_input_flatten_for_fixed_array, impl_input_flatten_for_tuple};
 
+/// Provides functionality to flatten and unflatten input data for circuits.
+///
+/// This trait is designed to work with types that can be copied, ensuring that the data can be
+/// easily duplicated when necessary. It includes methods for flattening data into a vector and
+/// unflattening data from a vector, with optional parameters for the unflattening process.
+///
+/// Implementors of this trait must specify the number of field elements (`NUM_FE`) that the
+/// flattened data will contain. This is used to ensure that the input data has the correct length
+/// when unflattening.
 pub trait InputFlatten<T: Copy>: Sized {
+    /// Type `Params` is used to provide additional parameters that may be required for the unflattening process.
+    /// It defaults to `()` when no additional parameters are needed.
     type Params: Default = ();
     const NUM_FE: usize;
     fn flatten_vec(&self) -> Vec<T>;
     fn unflatten(vec: Vec<T>) -> Result<Self>;
-    fn params(&self) -> Self::Params {
-        Self::Params::default()
-    }
     fn unflatten_with_params(vec: Vec<T>, _params: Self::Params) -> Result<Self> {
         Self::unflatten(vec)
     }

--- a/circuit/src/input/raw_input.rs
+++ b/circuit/src/input/raw_input.rs
@@ -88,8 +88,8 @@ impl<F: Field, const N: usize> RawInput<F> for FixLenVec<usize, N> {
     type FEType<T: Copy> = [T; N];
     fn convert(&self) -> Self::FEType<F> {
         let mut res = [F::ZERO; N];
-        for i in 0..N {
-            res[i] = F::from(self.0[i] as u64);
+        for (i, item) in res.iter_mut().enumerate().take(N) {
+            *item = F::from(self.0[i] as u64);
         }
         res
     }

--- a/circuit/src/run/aggregation.rs
+++ b/circuit/src/run/aggregation.rs
@@ -42,7 +42,7 @@ pub fn agg_circuit_keygen<T>(
 ) {
     let mut circuit =
         create_aggregation_circuit(agg_circuit_params, snark, CircuitBuilderStage::Keygen);
-    let mut calculated_params = agg_circuit_params.clone();
+    let mut calculated_params = agg_circuit_params;
     if should_calculate_params {
         calculated_params = circuit.calculate_params(Some(100));
     }

--- a/circuit/src/run/aggregation.rs
+++ b/circuit/src/run/aggregation.rs
@@ -29,16 +29,16 @@ pub fn agg_circuit_mock(agg_circuit_params: AggregationCircuitParams, snark: Sna
         .assert_satisfied();
 }
 
-pub fn agg_circuit_keygen<T>(
+pub fn agg_circuit_keygen<CoreParams>(
     agg_circuit_params: AggregationCircuitParams,
     snark: Snark,
-    child_pinning: AxiomCircuitPinning<T>,
+    child_pinning: AxiomCircuitPinning<CoreParams>,
     params: &ParamsKZG<Bn256>,
     should_calculate_params: bool,
 ) -> (
     VerifyingKey<G1Affine>,
     ProvingKey<G1Affine>,
-    AggregationCircuitPinning<T>,
+    AggregationCircuitPinning<CoreParams>,
 ) {
     let mut circuit =
         create_aggregation_circuit(agg_circuit_params, snark, CircuitBuilderStage::Keygen);
@@ -57,8 +57,8 @@ pub fn agg_circuit_keygen<T>(
     (vk, pk, pinning)
 }
 
-pub fn agg_circuit_prove<T>(
-    agg_circuit_pinning: AggregationCircuitPinning<T>,
+pub fn agg_circuit_prove<CoreParams>(
+    agg_circuit_pinning: AggregationCircuitPinning<CoreParams>,
     snark: Snark,
     pk: ProvingKey<G1Affine>,
     params: &ParamsKZG<Bn256>,
@@ -72,8 +72,8 @@ pub fn agg_circuit_prove<T>(
     gen_snark_shplonk(params, &pk, circuit, None::<&str>)
 }
 
-pub fn agg_circuit_run<T>(
-    agg_circuit_pinning: AggregationCircuitPinning<T>,
+pub fn agg_circuit_run<CoreParams>(
+    agg_circuit_pinning: AggregationCircuitPinning<CoreParams>,
     inner_output: AxiomV2CircuitOutput,
     pk: ProvingKey<G1Affine>,
     params: &ParamsKZG<Bn256>,

--- a/circuit/src/run/aggregation.rs
+++ b/circuit/src/run/aggregation.rs
@@ -29,16 +29,16 @@ pub fn agg_circuit_mock(agg_circuit_params: AggregationCircuitParams, snark: Sna
         .assert_satisfied();
 }
 
-pub fn agg_circuit_keygen(
+pub fn agg_circuit_keygen<T>(
     agg_circuit_params: AggregationCircuitParams,
     snark: Snark,
-    child_pinning: AxiomCircuitPinning,
+    child_pinning: AxiomCircuitPinning<T>,
     params: &ParamsKZG<Bn256>,
     should_calculate_params: bool,
 ) -> (
     VerifyingKey<G1Affine>,
     ProvingKey<G1Affine>,
-    AggregationCircuitPinning,
+    AggregationCircuitPinning<T>,
 ) {
     let mut circuit =
         create_aggregation_circuit(agg_circuit_params, snark, CircuitBuilderStage::Keygen);
@@ -57,8 +57,8 @@ pub fn agg_circuit_keygen(
     (vk, pk, pinning)
 }
 
-pub fn agg_circuit_prove(
-    agg_circuit_pinning: AggregationCircuitPinning,
+pub fn agg_circuit_prove<T>(
+    agg_circuit_pinning: AggregationCircuitPinning<T>,
     snark: Snark,
     pk: ProvingKey<G1Affine>,
     params: &ParamsKZG<Bn256>,
@@ -72,8 +72,8 @@ pub fn agg_circuit_prove(
     gen_snark_shplonk(params, &pk, circuit, None::<&str>)
 }
 
-pub fn agg_circuit_run(
-    agg_circuit_pinning: AggregationCircuitPinning,
+pub fn agg_circuit_run<T>(
+    agg_circuit_pinning: AggregationCircuitPinning<T>,
     inner_output: AxiomV2CircuitOutput,
     pk: ProvingKey<G1Affine>,
     params: &ParamsKZG<Bn256>,

--- a/circuit/src/run/aggregation.rs
+++ b/circuit/src/run/aggregation.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     utils::{
         build_axiom_v2_compute_query, check_compute_proof_format, check_compute_query_format,
-        verify_snark, DK,
+        get_query_schema_from_compute_query, verify_snark, DK,
     },
 };
 
@@ -88,10 +88,13 @@ pub fn agg_circuit_run(
         agg_circuit_pinning.child_pinning.max_user_outputs,
     );
 
+    let query_schema = get_query_schema_from_compute_query(compute_query.clone()).unwrap();
+
     let circuit_output = AxiomV2CircuitOutput {
         compute_query,
         data: inner_output.data,
         snark: agg_snark,
+        query_schema,
     };
 
     let vk = pk.get_vk();

--- a/circuit/src/run/aggregation.rs
+++ b/circuit/src/run/aggregation.rs
@@ -34,13 +34,17 @@ pub fn agg_circuit_keygen(
     snark: Snark,
     child_pinning: AxiomCircuitPinning,
     params: &ParamsKZG<Bn256>,
+    should_calculate_params: bool,
 ) -> (
     VerifyingKey<G1Affine>,
     ProvingKey<G1Affine>,
     AggregationCircuitPinning,
 ) {
-    let circuit =
+    let mut circuit =
         create_aggregation_circuit(agg_circuit_params, snark, CircuitBuilderStage::Keygen);
+    if should_calculate_params {
+        circuit.calculate_params(Some(100));
+    }
     let vk = keygen_vk(params, &circuit).expect("Failed to generate vk");
     let pk = keygen_pk(params, vk.clone(), &circuit).expect("Failed to generate pk");
     let breakpoints = circuit.break_points();

--- a/circuit/src/run/aggregation.rs
+++ b/circuit/src/run/aggregation.rs
@@ -42,8 +42,9 @@ pub fn agg_circuit_keygen(
 ) {
     let mut circuit =
         create_aggregation_circuit(agg_circuit_params, snark, CircuitBuilderStage::Keygen);
+    let mut calculated_params = agg_circuit_params.clone();
     if should_calculate_params {
-        circuit.calculate_params(Some(100));
+        calculated_params = circuit.calculate_params(Some(100));
     }
     let vk = keygen_vk(params, &circuit).expect("Failed to generate vk");
     let pk = keygen_pk(params, vk.clone(), &circuit).expect("Failed to generate pk");
@@ -51,7 +52,7 @@ pub fn agg_circuit_keygen(
     let pinning = AggregationCircuitPinning {
         child_pinning,
         break_points: breakpoints,
-        params: agg_circuit_params,
+        params: calculated_params,
     };
     (vk, pk, pinning)
 }

--- a/circuit/src/run/aggregation.rs
+++ b/circuit/src/run/aggregation.rs
@@ -80,7 +80,7 @@ pub fn agg_circuit_run(
     );
     let circuit = circuit.use_break_points(agg_circuit_pinning.break_points);
     let agg_circuit_params = circuit.builder.config_params.clone();
-    let agg_snark = gen_snark_shplonk(&params, &pk, circuit, None::<&str>);
+    let agg_snark = gen_snark_shplonk(params, &pk, circuit, None::<&str>);
     let compute_query = build_axiom_v2_compute_query(
         agg_snark.clone(),
         AxiomCircuitParams::Base(agg_circuit_params.clone()),

--- a/circuit/src/run/inner.rs
+++ b/circuit/src/run/inner.rs
@@ -17,7 +17,7 @@ use crate::{
     types::{AxiomCircuitParams, AxiomCircuitPinning, AxiomV2CircuitOutput},
     utils::{
         build_axiom_v2_compute_query, check_compute_proof_format, check_compute_query_format,
-        verify_snark, DK,
+        get_query_schema_from_compute_query, verify_snark, DK,
     },
 };
 
@@ -113,10 +113,13 @@ pub fn run<P: JsonRpcClient + Clone, S: AxiomCircuitScaffold<P, Fr>>(
         }
     };
 
+    let query_schema = get_query_schema_from_compute_query(compute_query.clone()).unwrap();
+
     let circuit_output = AxiomV2CircuitOutput {
         compute_query,
         data: output,
         snark,
+        query_schema,
     };
 
     let vk = pk.get_vk();

--- a/circuit/src/run/inner.rs
+++ b/circuit/src/run/inner.rs
@@ -43,7 +43,7 @@ pub fn keygen<P: JsonRpcClient + Clone, S: AxiomCircuitScaffold<P, Fr>>(
 ) -> (
     VerifyingKey<G1Affine>,
     ProvingKey<G1Affine>,
-    AxiomCircuitPinning,
+    AxiomCircuitPinning<S::CoreParams>,
 ) {
     let raw_circuit_params = circuit.params();
     let circuit_params = RlcKeccakCircuitParams::from(raw_circuit_params.clone());

--- a/circuit/src/run/inner.rs
+++ b/circuit/src/run/inner.rs
@@ -80,10 +80,6 @@ pub fn run<P: JsonRpcClient + Clone, S: AxiomCircuitScaffold<P, Fr>>(
     let circuit_params = RlcKeccakCircuitParams::from(raw_circuit_params.clone());
     let k = circuit_params.k();
     let output = circuit.scaffold_output();
-    if circuit_params.keccak_rows_per_round > 0 {
-        circuit.calculate_params();
-        info!("Calculated params: {:?}", circuit.params());
-    }
     let max_user_outputs = circuit.max_user_outputs;
     let snark = gen_snark_shplonk(params, pk, circuit.clone(), None::<&str>);
     let compute_query = match raw_circuit_params {

--- a/circuit/src/run/inner.rs
+++ b/circuit/src/run/inner.rs
@@ -72,7 +72,7 @@ pub fn prove<P: JsonRpcClient + Clone, S: AxiomCircuitScaffold<P, Fr>>(
 }
 
 pub fn run<P: JsonRpcClient + Clone, S: AxiomCircuitScaffold<P, Fr>>(
-    circuit: &mut AxiomCircuit<Fr, P, S>,
+    circuit: AxiomCircuit<Fr, P, S>,
     pk: &ProvingKey<G1Affine>,
     params: &ParamsKZG<Bn256>,
 ) -> AxiomV2CircuitOutput {
@@ -81,7 +81,7 @@ pub fn run<P: JsonRpcClient + Clone, S: AxiomCircuitScaffold<P, Fr>>(
     let k = circuit_params.k();
     let output = circuit.scaffold_output();
     let max_user_outputs = circuit.max_user_outputs;
-    let snark = gen_snark_shplonk(params, pk, circuit.clone(), None::<&str>);
+    let snark = gen_snark_shplonk(params, pk, circuit, None::<&str>);
     let compute_query = match raw_circuit_params {
         AxiomCircuitParams::Base(_) => build_axiom_v2_compute_query(
             snark.clone(),
@@ -126,7 +126,7 @@ pub fn run<P: JsonRpcClient + Clone, S: AxiomCircuitScaffold<P, Fr>>(
             circuit_output.clone(),
             raw_circuit_params,
             vk.clone(),
-            circuit.max_user_outputs,
+            max_user_outputs,
         );
         verify_snark(&DK, &circuit_output.snark)
             .expect("Client snark failed to verify. Make sure you are using the right KZG params.");

--- a/circuit/src/scaffold.rs
+++ b/circuit/src/scaffold.rs
@@ -270,7 +270,6 @@ impl<F: Field, P: JsonRpcClient + Clone, A: AxiomCircuitScaffold<P, F>> AxiomCir
         }
         let is_inputs = self.inputs.is_none();
         let flattened_inputs = self.inputs.clone().unwrap_or_default().flatten_vec();
-        // let params = self.inputs.clone().unwrap_or_default().params();
         let assigned_input_vec = self
             .builder
             .borrow_mut()

--- a/circuit/src/tests/base.rs
+++ b/circuit/src/tests/base.rs
@@ -41,6 +41,7 @@ macro_rules! base_test_struct {
                 subquery_caller: Arc<Mutex<SubqueryCaller<P, Fr>>>,
                 _callback: &mut Vec<HiLo<AssignedValue<Fr>>>,
                 _inputs: Self::InputWitness,
+                _core_params: Self::CoreParams,
             ) {
                 $subquery_call(builder, subquery_caller);
             }

--- a/circuit/src/tests/keccak.rs
+++ b/circuit/src/tests/keccak.rs
@@ -57,6 +57,7 @@ macro_rules! keccak_test_struct {
                 subquery_caller: Arc<Mutex<SubqueryCaller<P, Fr>>>,
                 _callback: &mut Vec<HiLo<AssignedValue<Fr>>>,
                 _inputs: Self::InputWitness,
+                _core_params: Self::CoreParams,
             ) {
                 $subquery_call(builder, subquery_caller.clone());
                 let a = witness!(builder, Fr::from(1));

--- a/circuit/src/tests/keccak.rs
+++ b/circuit/src/tests/keccak.rs
@@ -180,6 +180,7 @@ pub fn test_compute_query<S: AxiomCircuitScaffold<Http, Fr>>(_circuit: S) {
         output.snark.clone(),
         pinning,
         &agg_kzg_params,
+        false,
     );
     let final_output = agg_circuit_run(agg_pinning, output.clone(), agg_pk, &agg_kzg_params);
     let circuit = create_aggregation_circuit(

--- a/circuit/src/tests/keccak.rs
+++ b/circuit/src/tests/keccak.rs
@@ -173,8 +173,8 @@ pub fn test_compute_query<S: AxiomCircuitScaffold<Http, Fr>>(_circuit: S) {
     let mut runner = AxiomCircuit::<_, _, S>::new(client.clone(), params);
     let kzg_params = gen_srs(runner.k() as u32);
     let (_, pk, pinning) = keygen::<_, S>(&mut runner, &kzg_params);
-    let mut runner = AxiomCircuit::<_, _, S>::prover(client, pinning.clone());
-    let output = run::<_, S>(&mut runner, &pk, &kzg_params);
+    let runner = AxiomCircuit::<_, _, S>::prover(client, pinning.clone());
+    let output = run::<_, S>(runner, &pk, &kzg_params);
     let agg_kzg_params = gen_srs(agg_circuit_params.degree);
     let (agg_vk, agg_pk, agg_pinning) = agg_circuit_keygen(
         agg_circuit_params,

--- a/circuit/src/tests/rlc.rs
+++ b/circuit/src/tests/rlc.rs
@@ -41,6 +41,7 @@ macro_rules! rlc_test_struct {
                 subquery_caller: Arc<Mutex<SubqueryCaller<P, Fr>>>,
                 _callback: &mut Vec<HiLo<AssignedValue<Fr>>>,
                 _inputs: Self::InputWitness,
+                _core_params: Self::CoreParams,
             ) {
                 $subquery_call(builder, subquery_caller);
             }

--- a/circuit/src/tests/shared_tests.rs
+++ b/circuit/src/tests/shared_tests.rs
@@ -78,8 +78,8 @@ pub fn check_compute_proof_and_query_format<S: AxiomCircuitScaffold<Http, Fr>>(
     let mut runner = AxiomCircuit::<_, _, S>::new(client.clone(), params.clone());
     let kzg_params = gen_srs(runner.k() as u32);
     let (vk, pk, pinning) = keygen::<_, S>(&mut runner, &kzg_params);
-    let mut runner = AxiomCircuit::<_, _, S>::prover(client, pinning);
-    let output = run::<_, S>(&mut runner, &pk, &kzg_params);
+    let runner = AxiomCircuit::<_, _, S>::prover(client, pinning);
+    let output = run::<_, S>(runner, &pk, &kzg_params);
     check_compute_proof_format(output.clone(), is_aggregation);
     check_compute_query_format(output, params, vk, USER_MAX_OUTPUTS);
 }

--- a/circuit/src/types.rs
+++ b/circuit/src/types.rs
@@ -68,6 +68,7 @@ pub struct AxiomV2CircuitOutput {
     pub compute_query: AxiomV2ComputeQuery,
     #[serde(flatten)]
     pub data: AxiomV2DataAndResults,
+    pub query_schema: H256,
     #[serde(skip_serializing)]
     pub snark: Snark,
 }

--- a/circuit/src/types.rs
+++ b/circuit/src/types.rs
@@ -46,7 +46,8 @@ impl Default for AxiomCircuitParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AxiomCircuitPinning {
+pub struct AxiomCircuitPinning<T> {
+    pub core_params: T,
     pub params: AxiomCircuitParams,
     pub break_points: RlcThreadBreakPoints,
     pub max_user_outputs: usize,
@@ -54,8 +55,8 @@ pub struct AxiomCircuitPinning {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AggregationCircuitPinning {
-    pub child_pinning: AxiomCircuitPinning,
+pub struct AggregationCircuitPinning<T> {
+    pub child_pinning: AxiomCircuitPinning<T>,
     pub break_points: MultiPhaseThreadBreakPoints,
     pub params: AggregationCircuitParams,
 }

--- a/circuit/src/types.rs
+++ b/circuit/src/types.rs
@@ -46,8 +46,8 @@ impl Default for AxiomCircuitParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AxiomCircuitPinning<T> {
-    pub core_params: T,
+pub struct AxiomCircuitPinning<CoreParams> {
+    pub core_params: CoreParams,
     pub params: AxiomCircuitParams,
     pub break_points: RlcThreadBreakPoints,
     pub max_user_outputs: usize,
@@ -55,8 +55,8 @@ pub struct AxiomCircuitPinning<T> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AggregationCircuitPinning<T> {
-    pub child_pinning: AxiomCircuitPinning<T>,
+pub struct AggregationCircuitPinning<CoreParams> {
+    pub child_pinning: AxiomCircuitPinning<CoreParams>,
     pub break_points: MultiPhaseThreadBreakPoints,
     pub params: AggregationCircuitParams,
 }
@@ -64,8 +64,8 @@ pub struct AggregationCircuitPinning<T> {
 #[derive(Debug, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AxiomV2DataAndResults {
-    pub(crate) data_query: Vec<Subquery>,
-    pub(crate) compute_results: Vec<H256>,
+    pub data_query: Vec<Subquery>,
+    pub compute_results: Vec<H256>,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/circuit/src/types.rs
+++ b/circuit/src/types.rs
@@ -1,19 +1,24 @@
+use std::collections::HashMap;
+
 use axiom_codec::types::native::AxiomV2ComputeQuery;
-use axiom_query::axiom_eth::{
-    halo2_base::gates::{
-        circuit::{BaseCircuitParams, BaseConfig},
-        flex_gate::MultiPhaseThreadBreakPoints,
+use axiom_query::{
+    axiom_eth::{
+        halo2_base::gates::{
+            circuit::{BaseCircuitParams, BaseConfig},
+            flex_gate::MultiPhaseThreadBreakPoints,
+        },
+        rlc::{
+            circuit::{RlcCircuitParams, RlcConfig},
+            virtual_region::RlcThreadBreakPoints,
+        },
+        snark_verifier_sdk::Snark,
+        utils::{
+            keccak::decorator::{RlcKeccakCircuitParams, RlcKeccakConfig},
+            snark_verifier::AggregationCircuitParams,
+        },
+        Field,
     },
-    rlc::{
-        circuit::{RlcCircuitParams, RlcConfig},
-        virtual_region::RlcThreadBreakPoints,
-    },
-    snark_verifier_sdk::Snark,
-    utils::{
-        keccak::decorator::{RlcKeccakCircuitParams, RlcKeccakConfig},
-        snark_verifier::AggregationCircuitParams,
-    },
-    Field,
+    utils::client_circuit::metadata::AxiomV2CircuitMetadata,
 };
 use ethers::types::H256;
 use serde::{Deserialize, Serialize};
@@ -90,4 +95,16 @@ impl From<AxiomCircuitParams> for RlcKeccakCircuitParams {
             AxiomCircuitParams::Keccak(params) => params,
         }
     }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AxiomClientCircuitMetadata {
+    pub metadata: AxiomV2CircuitMetadata,
+    pub circuit_id: String,
+    pub data_query_size: HashMap<usize, usize>,
+    pub agg_circuit_id: Option<String>,
+    pub max_user_outputs: usize,
+    pub max_user_subqueries: usize,
+    pub preprocessed_len: usize,
+    pub query_schema: H256,
 }

--- a/circuit/src/utils.rs
+++ b/circuit/src/utils.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use anyhow::anyhow;
 use axiom_codec::{
+    encoder::native::get_query_schema_hash,
     types::native::{AxiomV2ComputeQuery, AxiomV2ComputeSnark, SubqueryResult},
     utils::native::decode_hilo_to_h256,
     HiLo,
@@ -42,7 +43,7 @@ use axiom_query::{
 use dotenv::dotenv;
 use ethers::{
     providers::{Http, Provider},
-    types::Bytes,
+    types::{Bytes, H256},
 };
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -283,6 +284,17 @@ pub fn verify_snark(dk: &KzgDecidingKey<Bn256>, snark: &Snark) -> anyhow::Result
     PlonkVerifier::verify(dk, &snark.protocol, &snark.instances, &proof)
         .map_err(|_| anyhow!("PlonkVerifier failed"))?;
     Ok(())
+}
+
+/// This function gets query schema from an AxiomV2ComputeQuery
+pub fn get_query_schema_from_compute_query(
+    compute_query: AxiomV2ComputeQuery,
+) -> anyhow::Result<H256> {
+    Ok(get_query_schema_hash(
+        compute_query.k,
+        compute_query.result_len,
+        &compute_query.vkey,
+    )?)
 }
 
 lazy_static! {

--- a/circuit/src/utils.rs
+++ b/circuit/src/utils.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{collections::HashMap, env};
 
 use anyhow::anyhow;
 use axiom_codec::{
@@ -10,28 +10,36 @@ use axiom_codec::{
 use axiom_query::{
     axiom_eth::{
         halo2_base::{
-            gates::{GateInstructions, RangeChip, RangeInstructions},
+            gates::{circuit::BaseCircuitParams, GateInstructions, RangeChip, RangeInstructions},
             utils::{biguint_to_fe, modulus},
             AssignedValue, Context,
             QuantumCell::Constant,
         },
-        halo2_proofs::plonk::VerifyingKey,
+        halo2_proofs::{
+            plonk::{Circuit, VerifyingKey},
+            poly::kzg::commitment::ParamsKZG,
+        },
         halo2curves::{
-            bn256::{Bn256, G1Affine},
+            bn256::{Bn256, Fr, G1Affine},
             group::GroupEncoding,
         },
+        rlc::circuit::RlcCircuitParams,
         snark_verifier::{
             pcs::{
                 kzg::{KzgAccumulator, KzgDecidingKey, LimbsEncoding},
                 AccumulatorEncoding,
             },
+            system::halo2::{compile, Config},
             verifier::{plonk::PlonkProof, SnarkVerifier},
         },
         snark_verifier_sdk::{
-            halo2::{PoseidonTranscript, POSEIDON_SPEC},
-            NativeLoader, PlonkVerifier, Snark, BITS, LIMBS, SHPLONK,
+            halo2::{aggregation::AggregationCircuit, PoseidonTranscript, POSEIDON_SPEC},
+            CircuitExt, NativeLoader, PlonkVerifier, Snark, BITS, LIMBS, SHPLONK,
         },
-        utils::{keccak::decorator::RlcKeccakCircuitParams, snark_verifier::NUM_FE_ACCUMULATOR},
+        utils::{
+            build_utils::keygen::get_circuit_id, keccak::decorator::RlcKeccakCircuitParams,
+            snark_verifier::NUM_FE_ACCUMULATOR,
+        },
         Field,
     },
     components::results::types::LogicOutputResultsRoot,
@@ -42,7 +50,7 @@ use axiom_query::{
 };
 use dotenv::dotenv;
 use ethers::{
-    providers::{Http, Provider},
+    providers::{Http, JsonRpcClient, Provider},
     types::{Bytes, H256},
 };
 use itertools::Itertools;
@@ -51,7 +59,12 @@ use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::One;
 
-use crate::types::{AxiomCircuitParams, AxiomV2CircuitOutput, AxiomV2DataAndResults};
+use crate::{
+    scaffold::{AxiomCircuit, AxiomCircuitScaffold},
+    types::{
+        AxiomCircuitParams, AxiomClientCircuitMetadata, AxiomV2CircuitOutput, AxiomV2DataAndResults,
+    },
+};
 
 const NUM_BYTES_ACCUMULATOR: usize = 64;
 
@@ -295,6 +308,114 @@ pub fn get_query_schema_from_compute_query(
         compute_query.result_len,
         &compute_query.vkey,
     )?)
+}
+
+/// This function gets AxiomClientCircuitMetadata from AxiomV2DataAndResults and vkey
+pub fn get_axiom_client_circuit_metadata<
+    P: JsonRpcClient + Clone,
+    S: AxiomCircuitScaffold<P, Fr>,
+>(
+    circuit: &AxiomCircuit<Fr, P, S>,
+    kzg_params: &ParamsKZG<Bn256>,
+    vk: &VerifyingKey<G1Affine>,
+) -> AxiomClientCircuitMetadata {
+    let circuit_output = circuit.scaffold_output();
+    let protocol = compile(
+        kzg_params,
+        vk,
+        Config::kzg().with_num_instance(circuit.num_instance()),
+    );
+    let params = circuit.params();
+    let rlc_keccak_params = RlcKeccakCircuitParams::from(params);
+    let rlc_params = rlc_keccak_params.clone().rlc;
+    let metadata =
+        get_metadata_from_protocol(&protocol, rlc_params, circuit.max_user_outputs).unwrap();
+    let k = rlc_keccak_params.k();
+    let circuit_id = get_circuit_id(vk);
+    let partial_vk = get_onchain_vk_from_protocol(&protocol, metadata.clone());
+    let partial_vk_output = write_onchain_vkey(&partial_vk).unwrap();
+    let query_schema = get_query_schema_hash(
+        k as u8,
+        circuit_output.compute_results.len() as u16,
+        &partial_vk_output,
+    )
+    .unwrap();
+
+    let mut data_query_size: HashMap<usize, usize> = HashMap::new();
+    for subquery in circuit_output.data_query.iter() {
+        let subquery_type = subquery.subquery_type;
+        *data_query_size.entry(subquery_type as usize).or_insert(0) += 1;
+    }
+
+    AxiomClientCircuitMetadata {
+        metadata,
+        circuit_id,
+        agg_circuit_id: None,
+        preprocessed_len: protocol.preprocessed.len(),
+        max_user_outputs: circuit.max_user_outputs,
+        max_user_subqueries: circuit.max_user_subqueries,
+        query_schema,
+        data_query_size,
+    }
+}
+
+/// This function gets AxiomClientCircuitMetadata from AxiomV2DataAndResults and vkey
+pub fn get_agg_axiom_client_circuit_metadata<
+    P: JsonRpcClient + Clone,
+    S: AxiomCircuitScaffold<P, Fr>,
+>(
+    circuit: &AxiomCircuit<Fr, P, S>,
+    kzg_params: &ParamsKZG<Bn256>,
+    vk: &VerifyingKey<G1Affine>,
+    agg_vk: &VerifyingKey<G1Affine>,
+    agg_params: BaseCircuitParams,
+) -> AxiomClientCircuitMetadata {
+    let circuit_output = circuit.scaffold_output();
+    let mut num_instance = circuit.num_instance();
+    debug_assert_eq!(num_instance.len(), 1);
+    num_instance[0] += NUM_FE_ACCUMULATOR;
+    let protocol = compile(
+        kzg_params,
+        agg_vk,
+        Config::kzg()
+            .with_num_instance(num_instance)
+            .with_accumulator_indices(AggregationCircuit::accumulator_indices()),
+    );
+    let rlc_params = RlcCircuitParams {
+        base: agg_params,
+        num_rlc_columns: 0,
+    };
+    let metadata =
+        get_metadata_from_protocol(&protocol, rlc_params.clone(), circuit.max_user_outputs)
+            .unwrap();
+    let k = rlc_params.base.k;
+    let agg_circuit_id = get_circuit_id(agg_vk);
+    let circuit_id = get_circuit_id(vk);
+    let partial_vk = get_onchain_vk_from_protocol(&protocol, metadata.clone());
+    let partial_vk_output = write_onchain_vkey(&partial_vk).unwrap();
+    let query_schema = get_query_schema_hash(
+        k as u8,
+        circuit_output.compute_results.len() as u16,
+        &partial_vk_output,
+    )
+    .unwrap();
+
+    let mut data_query_size: HashMap<usize, usize> = HashMap::new();
+    for subquery in circuit_output.data_query.iter() {
+        let subquery_type = subquery.subquery_type;
+        *data_query_size.entry(subquery_type as usize).or_insert(0) += 1;
+    }
+
+    AxiomClientCircuitMetadata {
+        metadata,
+        circuit_id,
+        agg_circuit_id: Some(agg_circuit_id),
+        preprocessed_len: protocol.preprocessed.len(),
+        max_user_outputs: circuit.max_user_outputs,
+        max_user_subqueries: circuit.max_user_subqueries,
+        query_schema,
+        data_query_size,
+    }
 }
 
 lazy_static! {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -23,3 +23,5 @@ log = "0.4"
 env_logger = "0.9"
 bincode = "1.3.3"
 rocket = { version = "0.5", features = ["json"] }
+dirs = "5.0.1"
+reqwest = {version = "0.12.3", features = ["blocking"]}

--- a/sdk/data/keccak_config.json
+++ b/sdk/data/keccak_config.json
@@ -13,10 +13,10 @@
     "num_rlc_columns": 0,
     "keccak_rows_per_round": 50,
     "agg_params": {
-        "degree": 21,
+        "degree": 16,
         "num_advice": 11,
         "num_lookup_advice": 1,
         "num_fixed": 1,
-        "lookup_bits": 20
+        "lookup_bits": 15
     }
 }

--- a/sdk/data/keccak_config.json
+++ b/sdk/data/keccak_config.json
@@ -1,5 +1,5 @@
 {
-    "k": 15,
+    "k": 17,
     "num_advice_per_phase": [
         5,
         0
@@ -11,12 +11,12 @@
     ],
     "lookup_bits": 14,
     "num_rlc_columns": 0,
-    "keccak_rows_per_round": 50,
+    "keccak_rows_per_round": 20,
     "agg_params": {
-        "degree": 16,
-        "num_advice": 11,
-        "num_lookup_advice": 1,
+        "degree": 20,
+        "num_advice": 13,
+        "num_lookup_advice": 2,
         "num_fixed": 1,
-        "lookup_bits": 15
+        "lookup_bits": 19
     }
 }

--- a/sdk/examples/account_age.rs
+++ b/sdk/examples/account_age.rs
@@ -48,6 +48,8 @@ impl AxiomComputeFn for AccountAgeInput {
     }
 }
 
+// axiom_compute_prover_server!(AccountAgeInput);
+
 fn main() {
     run_cli::<AccountAgeInput>();
 }

--- a/sdk/examples/keccak.rs
+++ b/sdk/examples/keccak.rs
@@ -37,3 +37,5 @@ impl AxiomComputeFn for KeccakInput {
 fn main() {
     run_cli::<KeccakInput>();
 }
+
+// axiom_compute_prover_server!(KeccakInput);

--- a/sdk/examples/rlc.rs
+++ b/sdk/examples/rlc.rs
@@ -28,6 +28,7 @@ impl AxiomComputeFn for RlcInput {
     fn compute_phase0(
         _: &mut AxiomAPI,
         assigned_inputs: Self::Input<AssignedValue<Fr>>,
+        _: Self::CoreParams,
     ) -> (Vec<AxiomResult>, Self::FirstPhasePayload) {
         (
             vec![],

--- a/sdk/src/cmd/mod.rs
+++ b/sdk/src/cmd/mod.rs
@@ -39,16 +39,6 @@ use crate::{
     Fr,
 };
 
-impl std::fmt::Display for SnarkCmd {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Mock => write!(f, "mock"),
-            Self::Keygen => write!(f, "keygen"),
-            Self::Run => write!(f, "run"),
-        }
-    }
-}
-
 /// Runs the CLI given on any struct that implements the `AxiomComputeFn` trait
 pub fn run_cli_on_scaffold<
     A: AxiomCircuitScaffold<Http, Fr>,

--- a/sdk/src/cmd/mod.rs
+++ b/sdk/src/cmd/mod.rs
@@ -141,11 +141,11 @@ pub fn run_cli_on_scaffold<
 
     let mut runner = AxiomCircuit::<Fr, Http, A>::new(provider.clone(), params)
         .use_max_user_outputs(max_user_outputs)
-        .use_max_user_subqueries(max_subqueries);
+        .use_max_user_subqueries(max_subqueries)
+        .use_inputs(input.clone());
 
     match cli.command {
         SnarkCmd::Mock => {
-            runner.set_inputs(input);
             mock(&mut runner);
         }
         SnarkCmd::Keygen => {

--- a/sdk/src/cmd/mod.rs
+++ b/sdk/src/cmd/mod.rs
@@ -68,10 +68,16 @@ pub fn run_cli_on_scaffold<
             if cli.degree.is_none() && cli.config.is_none() {
                 panic!("The `degree` argument is required for the selected command.");
             }
+            if cli.degree.is_some() && cli.config.is_some() {
+                warn!("The `degree` argument is ignored when a `config` file is provided.");
+            }
         }
         _ => {
             if cli.degree.is_some() {
                 warn!("The `degree` argument is not used for the selected command.");
+            }
+            if cli.config.is_some() {
+                warn!("The `config` argument is not used for the selected command.");
             }
         }
     }
@@ -127,8 +133,16 @@ pub fn run_cli_on_scaffold<
             AxiomCircuitParams::Base(base_params)
         }
     } else {
+        let degree = if cli.command == SnarkCmd::Run {
+            // The k will be read from the pinning file instead
+            12
+        } else {
+            cli.degree
+                .expect("The `degree` argument is required for the selected command.")
+                as usize
+        };
         AxiomCircuitParams::Base(BaseCircuitParams {
-            k: cli.degree.unwrap() as usize,
+            k: degree,
             num_advice_per_phase: vec![4],
             num_fixed: 1,
             num_lookup_advice_per_phase: vec![1],

--- a/sdk/src/cmd/mod.rs
+++ b/sdk/src/cmd/mod.rs
@@ -170,8 +170,14 @@ pub fn run_cli_on_scaffold<
                     read_srs_from_dir(&srs_path, agg_circuit_params.unwrap().degree)
                         .expect("Unable to read SRS");
                 let agg_params = agg_circuit_params.unwrap();
-                let agg_keygen_output =
-                    agg_circuit_keygen(agg_params, output.snark, pinning, &agg_kzg_params);
+                let agg_keygen_output = agg_circuit_keygen(
+                    agg_params,
+                    output.snark,
+                    pinning,
+                    &agg_kzg_params,
+                    cli.should_auto_config_aggregation_circuit,
+                );
+                let agg_params = agg_keygen_output.2.params.clone();
                 let agg_vk = agg_keygen_output.0.clone();
                 write_agg_keygen_output(agg_keygen_output, data_path.clone());
                 get_agg_axiom_client_circuit_metadata(

--- a/sdk/src/cmd/types.rs
+++ b/sdk/src/cmd/types.rs
@@ -18,7 +18,7 @@ pub enum SnarkCmd {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 /// Struct for specifying custom circuit parameters via JSON
-pub struct RawCircuitParams {
+pub struct RawCircuitParams<T> {
     pub k: usize,
     pub num_advice_per_phase: Vec<usize>,
     pub num_fixed: usize,
@@ -29,6 +29,7 @@ pub struct RawCircuitParams {
     pub max_outputs: Option<usize>,
     pub max_subqueries: Option<usize>,
     pub agg_params: Option<AggregationCircuitParams>,
+    pub core_params: Option<T>,
 }
 
 #[derive(Parser, Debug)]

--- a/sdk/src/cmd/types.rs
+++ b/sdk/src/cmd/types.rs
@@ -90,4 +90,12 @@ pub struct AxiomCircuitRunnerOptions {
     )]
     /// Whether to aggregate the output
     pub should_aggregate: bool,
+
+    #[arg(
+        long = "auto-config-aggregation",
+        help = "Whether to aggregate the output (defaults to false)",
+        action
+    )]
+    /// Whether to auto calculate the aggregation params
+    pub should_auto_config_aggregation_circuit: bool,
 }

--- a/sdk/src/cmd/types.rs
+++ b/sdk/src/cmd/types.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use axiom_circuit::axiom_eth::utils::snark_verifier::AggregationCircuitParams;
+pub use clap::Parser;
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Subcommand)]
+/// Circuit CLI commands
+pub enum SnarkCmd {
+    /// Run the mock prover
+    Mock,
+    /// Generate new proving & verifying keys
+    Keygen,
+    /// Generate an Axiom compute query
+    Run,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+/// Struct for specifying custom circuit parameters via JSON
+pub struct RawCircuitParams {
+    pub k: usize,
+    pub num_advice_per_phase: Vec<usize>,
+    pub num_fixed: usize,
+    pub num_lookup_advice_per_phase: Vec<usize>,
+    pub lookup_bits: Option<usize>,
+    pub num_rlc_columns: Option<usize>,
+    pub keccak_rows_per_round: Option<usize>,
+    pub max_outputs: Option<usize>,
+    pub max_subqueries: Option<usize>,
+    pub agg_params: Option<AggregationCircuitParams>,
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+/// Command-line helper for building Axiom compute circuits
+pub struct AxiomCircuitRunnerOptions {
+    #[command(subcommand)]
+    /// The command to run
+    pub command: SnarkCmd,
+
+    #[arg(
+        short = 'k',
+        long = "degree",
+        help = "To determine the size of your circuit (12..25)"
+    )]
+    /// The degree of the circuit
+    pub degree: Option<u32>,
+
+    #[arg(short = 'p', long = "provider", help = "JSON RPC provider URI")]
+    /// The JSON RPC provider URI
+    pub provider: Option<String>,
+
+    #[arg(short, long = "input", help = "JSON inputs to feed into your circuit")]
+    /// The JSON inputs to feed into your circuit
+    pub input_path: Option<PathBuf>,
+
+    #[arg(short, long = "name", help = "Name of the output metadata file")]
+    /// Name of the output metadata file
+    pub name: Option<String>,
+
+    #[arg(
+        short,
+        long = "data-path",
+        help = "For saving build artifacts (optional)"
+    )]
+    /// The path to save build artifacts
+    pub data_path: Option<PathBuf>,
+
+    //Advanced options
+    #[arg(
+        short = 'c',
+        long = "config",
+        help = "For specifying custom circuit parameters (optional)"
+    )]
+    /// The path to a custom circuit configuration
+    pub config: Option<PathBuf>,
+
+    #[arg(
+        long = "srs",
+        help = "For specifying custom KZG params directory (defaults to `params`)"
+    )]
+    /// The path to the KZG params folder
+    pub srs: Option<PathBuf>,
+
+    #[arg(
+        long = "aggregate",
+        help = "Whether to aggregate the output (defaults to false)",
+        action
+    )]
+    /// Whether to aggregate the output
+    pub should_aggregate: bool,
+}

--- a/sdk/src/cmd/types.rs
+++ b/sdk/src/cmd/types.rs
@@ -5,7 +5,7 @@ pub use clap::Parser;
 use clap::Subcommand;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Subcommand)]
+#[derive(Clone, Copy, Debug, Subcommand, PartialEq)]
 /// Circuit CLI commands
 pub enum SnarkCmd {
     /// Run the mock prover

--- a/sdk/src/cmd/types.rs
+++ b/sdk/src/cmd/types.rs
@@ -18,7 +18,7 @@ pub enum SnarkCmd {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 /// Struct for specifying custom circuit parameters via JSON
-pub struct RawCircuitParams<T> {
+pub struct RawCircuitParams<CoreParams> {
     pub k: usize,
     pub num_advice_per_phase: Vec<usize>,
     pub num_fixed: usize,
@@ -29,7 +29,7 @@ pub struct RawCircuitParams<T> {
     pub max_outputs: Option<usize>,
     pub max_subqueries: Option<usize>,
     pub agg_params: Option<AggregationCircuitParams>,
-    pub core_params: Option<T>,
+    pub core_params: Option<CoreParams>,
 }
 
 #[derive(Parser, Debug)]

--- a/sdk/src/compute.rs
+++ b/sdk/src/compute.rs
@@ -272,13 +272,12 @@ where
         self.check_all_set();
         let provider = self.provider.clone().unwrap();
         let converted_input = self.input.clone().map(|input| input.into());
-        let mut runner =
-            AxiomCircuit::<_, _, Self>::prover(provider, self.pinning.clone().unwrap())
-                .use_inputs(converted_input)
-                .use_max_user_outputs(self.max_user_outputs)
-                .use_max_user_subqueries(self.max_user_subqueries);
+        let runner = AxiomCircuit::<_, _, Self>::prover(provider, self.pinning.clone().unwrap())
+            .use_inputs(converted_input)
+            .use_max_user_outputs(self.max_user_outputs)
+            .use_max_user_subqueries(self.max_user_subqueries);
         let kzg_params = self.kzg_params.clone().expect("KZG params not set");
-        run::<Http, Self>(&mut runner, &pk, &kzg_params)
+        run::<Http, Self>(runner, &pk, &kzg_params)
     }
 
     /// Returns an [AxiomCircuit] instance, for functions that expect the halo2 circuit trait

--- a/sdk/src/compute.rs
+++ b/sdk/src/compute.rs
@@ -33,8 +33,8 @@ pub trait AxiomComputeInput: Clone + Default + Debug {
     type LogicInput: Clone + Debug + Serialize + DeserializeOwned + Into<Self::Input<Fr>>;
     /// The type of the circuit input to the compute function
     type Input<T: Copy>: Clone + InputFlatten<T, Params = Self::CoreParams>;
-    /// Optional type to specify circuit params.
-    type CoreParams = ();
+    /// Optional type to specify circuit-specific configuration params
+    type CoreParams: Clone + Debug + Default + Serialize + DeserializeOwned = ();
 }
 
 /// A trait for specifying an Axiom Compute function
@@ -48,10 +48,12 @@ pub trait AxiomComputeFn: AxiomComputeInput {
         assigned_inputs: Self::Input<AssignedValue<Fr>>,
     ) -> Vec<AxiomResult>;
 
+    #[allow(unused_variables)]
     /// An optional function that overrides `compute` to specify phase0 circuit logic for circuits that require a challenge
     fn compute_phase0(
         api: &mut AxiomAPI,
         assigned_inputs: Self::Input<AssignedValue<Fr>>,
+        core_params: Self::CoreParams,
     ) -> (Vec<AxiomResult>, Self::FirstPhasePayload) {
         (Self::compute(api, assigned_inputs), Default::default())
     }
@@ -73,7 +75,7 @@ pub trait AxiomComputeFn: AxiomComputeInput {
 pub struct AxiomCompute<A: AxiomComputeFn> {
     provider: Option<Provider<Http>>,
     params: Option<AxiomCircuitParams>,
-    pinning: Option<AxiomCircuitPinning>,
+    pinning: Option<AxiomCircuitPinning<A::CoreParams>>,
     input: Option<A::LogicInput>,
     kzg_params: Option<ParamsKZG<Bn256>>,
     max_user_outputs: usize,
@@ -110,9 +112,10 @@ where
         subquery_caller: Arc<Mutex<SubqueryCaller<Http, Fr>>>,
         callback: &mut Vec<HiLo<AssignedValue<Fr>>>,
         assigned_inputs: Self::InputWitness,
+        core_params: Self::CoreParams,
     ) -> <A as AxiomComputeFn>::FirstPhasePayload {
         let mut api = AxiomAPI::new(builder, range, subquery_caller);
-        let (result, payload) = A::compute_phase0(&mut api, assigned_inputs);
+        let (result, payload) = A::compute_phase0(&mut api, assigned_inputs, core_params);
         let hilo_output = result
             .into_iter()
             .map(|result| match result {
@@ -159,7 +162,7 @@ where
     }
 
     /// Set the pinning for the AxiomCompute instance
-    pub fn set_pinning(&mut self, pinning: AxiomCircuitPinning) {
+    pub fn set_pinning(&mut self, pinning: AxiomCircuitPinning<A::CoreParams>) {
         self.pinning = Some(pinning);
     }
 
@@ -197,7 +200,7 @@ where
     }
 
     /// Use the given pinning for the AxiomCompute instance
-    pub fn use_pinning(mut self, pinning: AxiomCircuitPinning) -> Self {
+    pub fn use_pinning(mut self, pinning: AxiomCircuitPinning<A::CoreParams>) -> Self {
         self.set_pinning(pinning);
         self
     }
@@ -252,7 +255,7 @@ where
     ) -> (
         VerifyingKey<G1Affine>,
         ProvingKey<G1Affine>,
-        AxiomCircuitPinning,
+        AxiomCircuitPinning<A::CoreParams>,
     ) {
         self.check_provider_and_params_set();
         let provider = self.provider.clone().unwrap();

--- a/sdk/src/compute.rs
+++ b/sdk/src/compute.rs
@@ -32,7 +32,9 @@ pub trait AxiomComputeInput: Clone + Default + Debug {
     /// The type of the native input (ie. Rust types) to the compute function
     type LogicInput: Clone + Debug + Serialize + DeserializeOwned + Into<Self::Input<Fr>>;
     /// The type of the circuit input to the compute function
-    type Input<T: Copy>: Clone + InputFlatten<T>;
+    type Input<T: Copy>: Clone + InputFlatten<T, Params = Self::CoreParams>;
+    /// Optional type to specify circuit params.
+    type CoreParams = ();
 }
 
 /// A trait for specifying an Axiom Compute function
@@ -99,6 +101,7 @@ where
 {
     type InputValue = A::Input<Fr>;
     type InputWitness = A::Input<AssignedValue<Fr>>;
+    type CoreParams = A::CoreParams;
     type FirstPhasePayload = A::FirstPhasePayload;
 
     fn virtual_assign_phase0(

--- a/sdk/src/utils/io.rs
+++ b/sdk/src/utils/io.rs
@@ -6,16 +6,91 @@ use std::{
 
 use axiom_circuit::{
     axiom_eth::{
-        halo2_proofs::{plonk::ProvingKey, SerdeFormat},
+        halo2_proofs::{
+            plonk::{ProvingKey, VerifyingKey},
+            SerdeFormat,
+        },
         halo2curves::bn256::{Fr, G1Affine},
         snark_verifier_sdk::halo2::aggregation::AggregationCircuit,
-        utils::snark_verifier::AggregationCircuitParams,
+        utils::{build_utils::keygen::get_circuit_id, snark_verifier::AggregationCircuitParams},
     },
     scaffold::{AxiomCircuit, AxiomCircuitScaffold},
-    types::{AggregationCircuitPinning, AxiomCircuitPinning, AxiomV2CircuitOutput},
+    types::{
+        AggregationCircuitPinning, AxiomCircuitPinning, AxiomClientCircuitMetadata,
+        AxiomV2CircuitOutput,
+    },
 };
 use ethers::providers::Http;
 use log::info;
+
+pub fn write_keygen_output(
+    vk: &VerifyingKey<G1Affine>,
+    pk: &ProvingKey<G1Affine>,
+    pinning: &AxiomCircuitPinning,
+    data_path: PathBuf,
+) -> String {
+    let circuit_id = get_circuit_id(vk);
+    let pk_path = data_path.join(format!("{circuit_id}.pk"));
+    let vk_path = data_path.join(format!("{circuit_id}.vk"));
+    let pinning_path = data_path.join(format!("{circuit_id}.json"));
+    write_vk(vk, vk_path);
+    write_pk(pk, pk_path);
+    write_pinning(pinning, pinning_path);
+    circuit_id
+}
+
+pub fn read_pk_and_pinning<A: AxiomCircuitScaffold<Http, Fr>>(
+    data_path: PathBuf,
+    circuit_id: String,
+    runner: &AxiomCircuit<Fr, Http, A>,
+) -> (ProvingKey<G1Affine>, AxiomCircuitPinning) {
+    let pk_path = data_path.join(format!("{circuit_id}.pk"));
+    let pinning_path = data_path.join(format!("{circuit_id}.json"));
+    let pinning = read_pinning(pinning_path);
+    let pk = read_pk(pk_path, &runner.clone().use_pinning(pinning.clone()));
+    (pk, pinning)
+}
+
+pub fn write_agg_keygen_output(
+    keygen_output: (
+        VerifyingKey<G1Affine>,
+        ProvingKey<G1Affine>,
+        AggregationCircuitPinning,
+    ),
+    data_path: PathBuf,
+) -> String {
+    let circuit_id = get_circuit_id(&keygen_output.0);
+    let pk_path = data_path.join(format!("{circuit_id}.pk"));
+    let vk_path = data_path.join(format!("{circuit_id}.vk"));
+    let pinning_path = data_path.join(format!("{circuit_id}.json"));
+    write_vk(&keygen_output.0, vk_path);
+    write_pk(&keygen_output.1, pk_path);
+    write_agg_pinning(&keygen_output.2, pinning_path);
+    circuit_id
+}
+
+pub fn read_agg_pk_and_pinning(
+    data_path: PathBuf,
+    circuit_id: String,
+) -> (ProvingKey<G1Affine>, AggregationCircuitPinning) {
+    let pk_path = data_path.join(format!("{circuit_id}.pk"));
+    let pinning_path = data_path.join(format!("{circuit_id}.json"));
+    let pinning = read_agg_pinning(pinning_path);
+    let pk = read_agg_pk(pk_path, pinning.params);
+    (pk, pinning)
+}
+
+pub fn write_vk(vk: &VerifyingKey<G1Affine>, vk_path: PathBuf) {
+    if vk_path.exists() {
+        fs::remove_file(&vk_path).unwrap();
+    }
+    let f =
+        File::create(&vk_path).unwrap_or_else(|_| panic!("Could not create file at {vk_path:?}"));
+    let mut writer = BufWriter::new(f);
+    vk.write(&mut writer, SerdeFormat::RawBytes)
+        .expect("writing vkey should not fail");
+    info!("Wrote verifying key to {:?}", vk_path);
+}
 
 pub fn write_pk(pk: &ProvingKey<G1Affine>, pk_path: PathBuf) {
     if pk_path.exists() {
@@ -27,6 +102,22 @@ pub fn write_pk(pk: &ProvingKey<G1Affine>, pk_path: PathBuf) {
     pk.write(&mut writer, SerdeFormat::RawBytes)
         .expect("writing pkey should not fail");
     info!("Wrote proving key to {:?}", pk_path);
+}
+
+pub fn write_metadata(metadata: AxiomClientCircuitMetadata, metadata_path: PathBuf) {
+    if metadata_path.exists() {
+        fs::remove_file(&metadata_path).unwrap();
+    }
+    let f = File::create(&metadata_path)
+        .unwrap_or_else(|_| panic!("Could not create file at {metadata_path:?}"));
+    serde_json::to_writer_pretty(&f, &metadata).expect("writing metadata should not fail");
+    info!("Wrote circuit metadata to {:?}", metadata_path);
+}
+
+pub fn read_metadata(metadata_path: PathBuf) -> AxiomClientCircuitMetadata {
+    info!("Reading circuit metadata from {:?}", &metadata_path);
+    let f = File::open(metadata_path).expect("metadata file should exist");
+    serde_json::from_reader(f).expect("reading circuit metadata should not fail")
 }
 
 pub fn read_pk<A: AxiomCircuitScaffold<Http, Fr>>(

--- a/sdk/src/utils/io.rs
+++ b/sdk/src/utils/io.rs
@@ -32,7 +32,7 @@ pub fn write_keygen_output(
     let circuit_id = get_circuit_id(vk);
     let pk_path = data_path.join(format!("{circuit_id}.pk"));
     let vk_path = data_path.join(format!("{circuit_id}.vk"));
-    let pinning_path = data_path.join(format!("{circuit_id}.json"));
+    let pinning_path = data_path.join(format!("{circuit_id}.pinning"));
     write_vk(vk, vk_path);
     write_pk(pk, pk_path);
     write_pinning(pinning, pinning_path);
@@ -45,7 +45,7 @@ pub fn read_pk_and_pinning<A: AxiomCircuitScaffold<Http, Fr>>(
     runner: &AxiomCircuit<Fr, Http, A>,
 ) -> (ProvingKey<G1Affine>, AxiomCircuitPinning) {
     let pk_path = data_path.join(format!("{circuit_id}.pk"));
-    let pinning_path = data_path.join(format!("{circuit_id}.json"));
+    let pinning_path = data_path.join(format!("{circuit_id}.pinning"));
     let pinning = read_pinning(pinning_path);
     let pk = read_pk(pk_path, &runner.clone().use_pinning(pinning.clone()));
     (pk, pinning)
@@ -62,7 +62,7 @@ pub fn write_agg_keygen_output(
     let circuit_id = get_circuit_id(&keygen_output.0);
     let pk_path = data_path.join(format!("{circuit_id}.pk"));
     let vk_path = data_path.join(format!("{circuit_id}.vk"));
-    let pinning_path = data_path.join(format!("{circuit_id}.json"));
+    let pinning_path = data_path.join(format!("{circuit_id}.pinning"));
     write_vk(&keygen_output.0, vk_path);
     write_pk(&keygen_output.1, pk_path);
     write_agg_pinning(&keygen_output.2, pinning_path);
@@ -74,7 +74,7 @@ pub fn read_agg_pk_and_pinning(
     circuit_id: String,
 ) -> (ProvingKey<G1Affine>, AggregationCircuitPinning) {
     let pk_path = data_path.join(format!("{circuit_id}.pk"));
-    let pinning_path = data_path.join(format!("{circuit_id}.json"));
+    let pinning_path = data_path.join(format!("{circuit_id}.pinning"));
     let pinning = read_agg_pinning(pinning_path);
     let pk = read_agg_pk(pk_path, pinning.params);
     (pk, pinning)

--- a/sdk/src/utils/io.rs
+++ b/sdk/src/utils/io.rs
@@ -22,11 +22,12 @@ use axiom_circuit::{
 };
 use ethers::providers::Http;
 use log::info;
+use serde::{de::DeserializeOwned, Serialize};
 
-pub fn write_keygen_output(
+pub fn write_keygen_output<T: Serialize>(
     vk: &VerifyingKey<G1Affine>,
     pk: &ProvingKey<G1Affine>,
-    pinning: &AxiomCircuitPinning,
+    pinning: &AxiomCircuitPinning<T>,
     data_path: PathBuf,
 ) -> String {
     let circuit_id = get_circuit_id(vk);
@@ -43,7 +44,10 @@ pub fn read_pk_and_pinning<A: AxiomCircuitScaffold<Http, Fr>>(
     data_path: PathBuf,
     circuit_id: String,
     runner: &AxiomCircuit<Fr, Http, A>,
-) -> (ProvingKey<G1Affine>, AxiomCircuitPinning) {
+) -> (ProvingKey<G1Affine>, AxiomCircuitPinning<A::CoreParams>)
+where
+    A::CoreParams: DeserializeOwned,
+{
     let pk_path = data_path.join(format!("{circuit_id}.pk"));
     let pinning_path = data_path.join(format!("{circuit_id}.pinning"));
     let pinning = read_pinning(pinning_path);
@@ -51,11 +55,11 @@ pub fn read_pk_and_pinning<A: AxiomCircuitScaffold<Http, Fr>>(
     (pk, pinning)
 }
 
-pub fn write_agg_keygen_output(
+pub fn write_agg_keygen_output<T: Serialize>(
     keygen_output: (
         VerifyingKey<G1Affine>,
         ProvingKey<G1Affine>,
-        AggregationCircuitPinning,
+        AggregationCircuitPinning<T>,
     ),
     data_path: PathBuf,
 ) -> String {
@@ -69,10 +73,10 @@ pub fn write_agg_keygen_output(
     circuit_id
 }
 
-pub fn read_agg_pk_and_pinning(
+pub fn read_agg_pk_and_pinning<T: DeserializeOwned>(
     data_path: PathBuf,
     circuit_id: String,
-) -> (ProvingKey<G1Affine>, AggregationCircuitPinning) {
+) -> (ProvingKey<G1Affine>, AggregationCircuitPinning<T>) {
     let pk_path = data_path.join(format!("{circuit_id}.pk"));
     let pinning_path = data_path.join(format!("{circuit_id}.pinning"));
     let pinning = read_agg_pinning(pinning_path);
@@ -142,7 +146,7 @@ pub fn read_agg_pk(pk_path: PathBuf, params: AggregationCircuitParams) -> Provin
         .expect("reading pkey should not fail")
 }
 
-pub fn write_pinning(pinning: &AxiomCircuitPinning, pinning_path: PathBuf) {
+pub fn write_pinning<T: Serialize>(pinning: &AxiomCircuitPinning<T>, pinning_path: PathBuf) {
     if pinning_path.exists() {
         fs::remove_file(&pinning_path).unwrap();
     }
@@ -152,7 +156,10 @@ pub fn write_pinning(pinning: &AxiomCircuitPinning, pinning_path: PathBuf) {
     info!("Wrote circuit pinning to {:?}", pinning_path);
 }
 
-pub fn write_agg_pinning(pinning: &AggregationCircuitPinning, pinning_path: PathBuf) {
+pub fn write_agg_pinning<T: Serialize>(
+    pinning: &AggregationCircuitPinning<T>,
+    pinning_path: PathBuf,
+) {
     if pinning_path.exists() {
         fs::remove_file(&pinning_path).unwrap();
     }
@@ -162,13 +169,15 @@ pub fn write_agg_pinning(pinning: &AggregationCircuitPinning, pinning_path: Path
     info!("Wrote circuit pinning to {:?}", pinning_path);
 }
 
-pub fn read_pinning(pinning_path: PathBuf) -> AxiomCircuitPinning {
+pub fn read_pinning<T: DeserializeOwned>(pinning_path: PathBuf) -> AxiomCircuitPinning<T> {
     info!("Reading circuit pinning from {:?}", &pinning_path);
     let f = File::open(pinning_path).expect("pinning file should exist");
     serde_json::from_reader(f).expect("reading circuit pinning should not fail")
 }
 
-pub fn read_agg_pinning(pinning_path: PathBuf) -> AggregationCircuitPinning {
+pub fn read_agg_pinning<T: DeserializeOwned>(
+    pinning_path: PathBuf,
+) -> AggregationCircuitPinning<T> {
     info!("Reading agg circuit pinning from {:?}", &pinning_path);
     let f = File::open(pinning_path).expect("pinning file should exist");
     serde_json::from_reader(f).expect("reading circuit pinning should not fail")


### PR DESCRIPTION
* computes + outputs query schema
* saves client circuit metadata during keygen
* allows for passing context with the circuit input flatten function (to pass any required context that's not actually part of the circuit input)
* removes auto-config circuit during the `run` command
* adds `--auto-config-aggregation` for calculating agg circuit params
* sets default kzg param location to ~/.axiom/srs/challenge_0085/ and installs if it doesn't exist